### PR TITLE
Fix outputs order

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,8 +27,8 @@ copyright = "This work is licensed under a Creative Commons Attribution-ShareAli
 	page = [ "HTML" ]
 	home = [ "HTML", "RSS" ]
 	section = [ "HTML", "RSS" ]
-	taxonomy = [ "Calendar", "HTML", "RSS" ]
-	taxonomyTerm = [ "Calendar", "HTML", "RSS" ]
+	taxonomy = [ "HTML", "Calendar", "RSS" ]
+	taxonomyTerm = [ "HTML", "Calendar", "RSS" ]
 
 [permalinks]
 	post = "/post/:year/:month/:day/:slug/"


### PR DESCRIPTION
Only the main output format (the first) can currently have paginators. We fixed this in Hugo 0.43, which broke your site. Putting HTML first should fix this.